### PR TITLE
Add minor gl version hint

### DIFF
--- a/seurat/viewer/butterfly/butterfly.cc
+++ b/seurat/viewer/butterfly/butterfly.cc
@@ -214,6 +214,7 @@ int main(int argc, char** argv) {
 
   glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
   glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 
   window = glfwCreateWindow(kWindowWidth, kWindowHeight, "Butterfly", nullptr,
                             nullptr);


### PR DESCRIPTION
On my ubuntu 18.04 vmware instance the butterfly window gets a glsl 3.0 renderer which causes the shaders to fail.  This fixes rendering in this case.